### PR TITLE
Update to unit service API endpoints

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 # NPSutils 1.1.0
+## 2025-09-15
+  * Update Unit service API to use current version (instead of discontinued legacy endpoint)
 ## 2025-05-16
   * Add a vignette going over basic functions and how to use NPSutils
 ## 2025-05-08

--- a/R/getParkUnitInfo.R
+++ b/R/getParkUnitInfo.R
@@ -26,7 +26,7 @@ get_unit_code <- function(unit) { # input must have quotes to indicate strings
   f <- file.path(tempdir(), "irmadownload.xml")
   if (!file.exists(f)) {
     # access all park codes from NPS xml file
-    curl::curl_download("https://irmaservices.nps.gov/v2/rest/unit/", f) 
+    curl::curl_download("https://irmaservices.nps.gov/unit/v2/api/", f) 
   }
   result <- XML::xmlParse(file = f) # parse xml
   dat <- XML::xmlToDataFrame(result) 
@@ -55,7 +55,7 @@ get_park_code <- function(park) {
   f <- file.path(tempdir(), "irmadownload.xml")
   if (!file.exists(f)) {
     # access all park codes from NPS xml file
-    curl::curl_download("https://irmaservices.nps.gov/v2/rest/unit/", f) 
+    curl::curl_download("https://irmaservices.nps.gov/unit/v2/api/", f) 
   }
   result <- XML::xmlParse(file = f)
   dat <- XML::xmlToDataFrame(result)
@@ -85,7 +85,7 @@ get_unit_code_info <- function(code) {
   f <- file.path(tempdir(), "irmadownload.xml")
   if (!file.exists(f)) {
     # access all park codes from NPS xml file
-    curl::curl_download(paste0("https://irmaservices.nps.gov/v2/rest/unit/", f))
+    curl::curl_download(paste0("https://irmaservices.nps.gov/unit/v2/api/", f))
   }
   result <- XML::xmlParse(file = f)
   dat <- XML::xmlToDataFrame(result)
@@ -131,7 +131,7 @@ get_unit_info <- function(code = NULL,
   f <- file.path(tempdir(), "irmadownload.xml")
   if (!file.exists(f)) {
     # access all park codes from NPS xml file
-    curl::curl_download("https://irmaservices.nps.gov/v2/rest/unit/", f) 
+    curl::curl_download("https://irmaservices.nps.gov/unit/v2/api/", f) 
   }
   result <- XML::xmlParse(file = f)
   dat <- XML::xmlToDataFrame(result)

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -36,8 +36,9 @@
     <div class="section level2">
 <h2 class="pkg-version" data-toc-text="1.1.0" id="npsutils-110">NPSutils 1.1.0<a class="anchor" aria-label="anchor" href="#npsutils-110"></a></h2>
 <div class="section level3">
-<h3 id="id_2025-1-1-0">2025-05-16<a class="anchor" aria-label="anchor" href="#id_2025-1-1-0"></a></h3>
-<ul><li>Add a vignette going over basic functions and how to use NPSutils ## 2025-05-08</li>
+<h3 id="id_2025-1-1-0">2025-09-15<a class="anchor" aria-label="anchor" href="#id_2025-1-1-0"></a></h3>
+<ul><li>Update Unit service API to use current version (instead of discontinued legacy endpoint) ## 2025-05-16</li>
+<li>Add a vignette going over basic functions and how to use NPSutils ## 2025-05-08</li>
 <li>add unit tests for all functions. Add packages necessary for unit tests to Suggests in DESCRIPTION file.</li>
 </ul></div>
 <div class="section level3">

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,7 +3,7 @@ pkgdown: 2.1.1
 pkgdown_sha: ~
 articles:
   NPSutils: NPSutils.html
-last_built: 2025-05-19T15:48Z
+last_built: 2025-09-15T21:47Z
 urls:
   reference: https://nationalparkservice.github.io/NPSutils/reference
   article: https://nationalparkservice.github.io/NPSutils/articles

--- a/docs/reference/get_data_packages.html
+++ b/docs/reference/get_data_packages.html
@@ -43,7 +43,7 @@
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="fu">get_data_packages</span><span class="op">(</span></span>
 <span>  <span class="va">reference_id</span>,</span>
 <span>  secure <span class="op">=</span> <span class="cn">FALSE</span>,</span>
-<span>  path <span class="op">=</span> <span class="fu">here</span><span class="fu">::</span><span class="fu"><a href="https://here.r-lib.org//reference/here.html" class="external-link">here</a></span><span class="op">(</span><span class="op">)</span>,</span>
+<span>  path <span class="op">=</span> <span class="fu">here</span><span class="fu">::</span><span class="fu"><a href="https://here.r-lib.org/reference/here.html" class="external-link">here</a></span><span class="op">(</span><span class="op">)</span>,</span>
 <span>  force <span class="op">=</span> <span class="cn">FALSE</span>,</span>
 <span>  dev <span class="op">=</span> <span class="cn">FALSE</span></span>
 <span><span class="op">)</span></span>
@@ -51,7 +51,7 @@
 <span><span class="fu">get_data_package</span><span class="op">(</span></span>
 <span>  <span class="va">reference_id</span>,</span>
 <span>  secure <span class="op">=</span> <span class="cn">FALSE</span>,</span>
-<span>  path <span class="op">=</span> <span class="fu">here</span><span class="fu">::</span><span class="fu"><a href="https://here.r-lib.org//reference/here.html" class="external-link">here</a></span><span class="op">(</span><span class="op">)</span>,</span>
+<span>  path <span class="op">=</span> <span class="fu">here</span><span class="fu">::</span><span class="fu"><a href="https://here.r-lib.org/reference/here.html" class="external-link">here</a></span><span class="op">(</span><span class="op">)</span>,</span>
 <span>  force <span class="op">=</span> <span class="cn">FALSE</span>,</span>
 <span>  dev <span class="op">=</span> <span class="cn">FALSE</span></span>
 <span><span class="op">)</span></span></code></pre></div>

--- a/docs/reference/load_data_packages.html
+++ b/docs/reference/load_data_packages.html
@@ -42,14 +42,14 @@
     <h2 id="ref-usage">Usage<a class="anchor" aria-label="anchor" href="#ref-usage"></a></h2>
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="fu">load_data_packages</span><span class="op">(</span></span>
 <span>  <span class="va">reference_id</span>,</span>
-<span>  directory <span class="op">=</span> <span class="fu">here</span><span class="fu">::</span><span class="fu"><a href="https://here.r-lib.org//reference/here.html" class="external-link">here</a></span><span class="op">(</span><span class="st">"data"</span><span class="op">)</span>,</span>
+<span>  directory <span class="op">=</span> <span class="fu">here</span><span class="fu">::</span><span class="fu"><a href="https://here.r-lib.org/reference/here.html" class="external-link">here</a></span><span class="op">(</span><span class="st">"data"</span><span class="op">)</span>,</span>
 <span>  assign_attributes <span class="op">=</span> <span class="cn">FALSE</span>,</span>
 <span>  simplify <span class="op">=</span> <span class="cn">TRUE</span></span>
 <span><span class="op">)</span></span>
 <span></span>
 <span><span class="fu">load_data_package</span><span class="op">(</span></span>
 <span>  <span class="va">reference_id</span>,</span>
-<span>  directory <span class="op">=</span> <span class="fu">here</span><span class="fu">::</span><span class="fu"><a href="https://here.r-lib.org//reference/here.html" class="external-link">here</a></span><span class="op">(</span><span class="st">"data"</span><span class="op">)</span>,</span>
+<span>  directory <span class="op">=</span> <span class="fu">here</span><span class="fu">::</span><span class="fu"><a href="https://here.r-lib.org/reference/here.html" class="external-link">here</a></span><span class="op">(</span><span class="st">"data"</span><span class="op">)</span>,</span>
 <span>  assign_attributes <span class="op">=</span> <span class="cn">FALSE</span>,</span>
 <span>  simplify <span class="op">=</span> <span class="cn">TRUE</span></span>
 <span><span class="op">)</span></span></code></pre></div>

--- a/docs/reference/rm_local_packages.html
+++ b/docs/reference/rm_local_packages.html
@@ -43,7 +43,7 @@
     <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="fu">rm_local_packages</span><span class="op">(</span></span>
 <span>  <span class="va">reference_id</span>,</span>
 <span>  all <span class="op">=</span> <span class="cn">FALSE</span>,</span>
-<span>  path <span class="op">=</span> <span class="fu">here</span><span class="fu">::</span><span class="fu"><a href="https://here.r-lib.org//reference/here.html" class="external-link">here</a></span><span class="op">(</span><span class="op">)</span>,</span>
+<span>  path <span class="op">=</span> <span class="fu">here</span><span class="fu">::</span><span class="fu"><a href="https://here.r-lib.org/reference/here.html" class="external-link">here</a></span><span class="op">(</span><span class="op">)</span>,</span>
 <span>  force <span class="op">=</span> <span class="cn">FALSE</span></span>
 <span><span class="op">)</span></span></code></pre></div>
     </div>


### PR DESCRIPTION
NPSutils was using legacy API endpoints, which were shut off due to security concerns (and being ancient). These changes update NPSutils to use the current API endpoints for the Unit service (still V2)